### PR TITLE
Fix create-db command

### DIFF
--- a/.github/workflows/sr.yml
+++ b/.github/workflows/sr.yml
@@ -20,5 +20,16 @@ jobs:
 
     - name: Python Semantic Release
       uses: python-semantic-release/python-semantic-release@master
+      id: release
+      with:
+        github_token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: steps.release.outputs.released == 'true'
+
+    - name: Publish package distributions to GitHub Releases
+      uses: python-semantic-release/upload-to-gh-release@main
+      if: steps.release.outputs.released == 'true'
       with:
         github_token: ${{ secrets.GH_ADMIN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ The information is
 
 ## Installation
 
-- Clone the repository
-- Install the requirements `poetry install`
+`pip install bcitflex`
 
-Note: Additionally a PostgreSQL instance is required for the database.
+### Prerequisites
+* A [PostgreSQL instance](https://www.postgresql.org/download/) is required for the database.
+* Dependency `psycopg2` requires `libpq-dev` to be installed for Ubuntu/Debian systems.
+```bash
+sudo apt install libpq-dev python3-dev
+```
+For more details see the [pycopg2 documentation](https://www.psycopg.org/docs/install.html#install-from-source) and [StackOverflow](https://stackoverflow.com/questions/5420789/how-to-install-psycopg2-with-pip-on-python).
 
 ### DB Setup
 
@@ -37,7 +42,7 @@ flask --app bcitflex create-db
 ```
 2. Build schema using alembic:
 ```bash
-poetry run alembic upgrade head
+flask --app bcitflex upgrade-db
 ```
 3. Populate the database with subjects from psql:
 ```bash
@@ -51,7 +56,7 @@ To run the webscraper and populate the database with the latest course offerings
 poetry run flask --app bcitflex load-db
 ```
 
-To run the webserver:
+To run the dev webserver:
 ```bash
 poetry run flask --app bcitflex run
 ```

--- a/bcitflex/db.py
+++ b/bcitflex/db.py
@@ -2,6 +2,7 @@
 import os
 import secrets
 import string
+import warnings
 from pathlib import Path
 
 import click
@@ -182,9 +183,11 @@ def init_app(app: Flask):
 
     if app.config.get("SQLALCHEMY_DATABASE_URI") is not None:
         db.init_app(app)
+        app.cli.add_command(load_db_command)
+        app.cli.add_command(upgrade_db_command)
     elif app.config.get("TESTING") is not True:
-        raise RuntimeError("SQLALCHEMY_DATABASE_URI not set in config.py")
+        warnings.warn(
+            "SQLALCHEMY_DATABASE_URI not set. App will not connect to db.", stacklevel=1
+        )
 
     app.cli.add_command(create_db_command)
-    app.cli.add_command(load_db_command)
-    app.cli.add_command(upgrade_db_command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ commit_parser = "angular"
 logging_use_named_masks = false
 major_on_zero = true
 tag_format = "v{version}"
+build_command = "poetry build"
 
 [tool.semantic_release.branches.main]
 match = "(main)"
@@ -128,7 +129,5 @@ env = "GH_TOKEN"
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = false
-upload_to_pypi = false
-build_command = false
 upload_to_repository = false
 upload_to_release = false

--- a/tests/app/test_db.py
+++ b/tests/app/test_db.py
@@ -127,12 +127,13 @@ class TestDBCommands:
         [
             (True, "test_url", "Database test_db created."),
             (False, "test_url", "Database test_db already exists."),
-            (True, None, "Database url already set in instance/config.py"),
+            (True, None, "Database url already set in instance\\config.py"),
         ],
     )
     def test_create_db_command(
         self, mock_app, mock_runner, monkeypatch, db_created, db_url, expected
     ):
+        # TODO: test more cases
         # mock psycopg2.connect so postgres is not required
         mock_connect = MagicMock()
         monkeypatch.setattr("psycopg2.connect", mock_connect)
@@ -149,7 +150,7 @@ class TestDBCommands:
         mock_app.instance_path = "instance"
 
         with mock_app.app_context():
-            result = mock_runner.invoke(args=["create-db", "--name=test_db"])
+            result = mock_runner.invoke(args=["create-db", "--dbname=test_db"])
 
         assert result.exit_code == 0
         assert expected in result.output

--- a/tests/app/test_db.py
+++ b/tests/app/test_db.py
@@ -215,5 +215,5 @@ def test_init_app(monkeypatch):
     create_app({"TESTING": True})
     mock_init_app.assert_not_called()
 
-    with pytest.raises(RuntimeError):
+    with pytest.warns(UserWarning):
         create_app({"SQLALCHEMY_DATABASE_URI": None})

--- a/tests/app/test_factory.py
+++ b/tests/app/test_factory.py
@@ -1,5 +1,4 @@
 """Test the app factory."""
-import pytest
 
 from bcitflex import create_app
 from tests import dbtest
@@ -11,5 +10,3 @@ def test_config():
     assert not create_app().testing
     assert create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": DB_URL}).testing
     assert create_app({"TESTING": True}).testing
-    with pytest.raises(RuntimeError):
-        create_app({"SQLALCHEMY_DATABASE_URI": None})


### PR DESCRIPTION
Fix create-db command so it can be run without config.

- [x] Don't connect to the database if config is not set.
- [x] Handle database exists.
- [x] Handle role exists.