### PR TITLE
fix(scraper): undelete objects on merge

### DIFF
--- a/bcitflex/scripts/scrape_and_load.py
+++ b/bcitflex/scripts/scrape_and_load.py
@@ -121,6 +121,7 @@ def parse_offering_node(node: Node, course: Course, term: Term) -> Offering:
         status=status,
         course=course,
         term_id=term.term_id,
+        deleted_at=None,
     )
 
     # parse meeting times
@@ -210,6 +211,7 @@ def parse_meeting_node(node: Node, offering: Offering, term: Term) -> Meeting:
         building=building,
         room=room,
         offering=offering,
+        deleted_at=None,
     )
 
 
@@ -231,6 +233,7 @@ def parse_course_info(page: CoursePage) -> Course:
         prerequisites=prerequisites,
         credits=credit_hours,
         url=page.url,
+        deleted_at=None,
     )
 
 
@@ -347,7 +350,6 @@ def load_courses(session: Session, courses: Iterator[Course]) -> int:
         # get course ids and merge
         for course in courses:
             course.set_id(session)
-            course.deleted_at = None
             session.merge(course)
 
     object_ct = len(session.dirty)

--- a/tests/scripts/test_scrape_and_load.py
+++ b/tests/scripts/test_scrape_and_load.py
@@ -96,6 +96,7 @@ class TestParseNodes:
     def test_parse_course_info(self, course_page: CoursePage):
         """Test the parse course function."""
         course = parse_course_info(course_page)
+        assert course.deleted_at is None
         assert course.credits > 0
 
     def test_parse_offering_node(
@@ -103,6 +104,7 @@ class TestParseNodes:
     ):
         """Test the parse offering node function."""
         offering = parse_offering_node(offering_node, existing_course, new_term)
+        assert offering.deleted_at is None
         assert offering.price > 0
         assert offering.crn == "38185"
 
@@ -111,6 +113,7 @@ class TestParseNodes:
     ):
         """Test the parse meeting node function."""
         meeting = parse_meeting_node(meeting_node, new_offering, new_term)
+        assert meeting.deleted_at is None
         assert meeting.start_date == datetime.date(2024, 9, 11)
         assert meeting.end_date == datetime.date(2024, 12, 11)
         assert meeting.days is None


### PR DESCRIPTION
On merge of an object set `deleted_at` to None, so it is un-deleted.