### PR TITLE
Implement course filters as SQL

### DIFF
--- a/bcitflex/app_functions/course_query.py
+++ b/bcitflex/app_functions/course_query.py
@@ -1,101 +1,56 @@
 """Filter courses."""
-from enum import Enum
 from typing import Type
 
-from functional import seq
-from sqlalchemy import Column, inspect
+from sqlalchemy import Column, ColumnExpressionArgument, Null, Select, select
+from sqlalchemy.orm import Mapper
 
-from bcitflex.model import Base, Course, Subject
-
-
-class Match(Enum):
-    EXACT = "EXACT"
-    PARTIAL = "PARTIAL"
-
-
-def coerce_to_column_type(model_column: Column, value: str | int) -> str | int:
-    """Coerce a value to the type of the given model column."""
-    column_data_type = model_column.type.python_type
-    return column_data_type(value)
+from bcitflex.model import Base
 
 
 class ModelFilter:
+    """Successively create a SQLAlchemy select statement with desired filters.
+
+    :param model: SQLAlchemy model to select
+    :param stmt: SQLAlchemy select statement
+    """
+
+    mapper: Mapper[Base]
+    model: Type[Base]
+    stmt: Select
+
     def __init__(self, model: Type[Base]):
         self.conditions: list[callable] = []
         self.model = model
-        self.mapper = inspect(model)
-        self.relationships = {
-            relationship.mapper.class_: relationship.key
-            for relationship in self.mapper.relationships
-        }
-
-    def __call__(self, obj: Type[Base]) -> bool:
-        return all(condition(obj) for condition in self.conditions)
+        self.stmt = select(model).distinct()
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.conditions})"
+        return f"ModelFilter({self.model.__name__})"
 
-    def add_condition(
-        self,
-        attr: str,
-        value: str | int | None,
-        relation: Type[Base] | None = None,
-        match: Match = Match.EXACT,
+    def where(
+        self, condition: ColumnExpressionArgument, links: list[Type[Base]] | None = None
     ):
-        """Return a function that returns True if the given model attribute
-        matches the given value.
+        """Add a condition to the select statement.
+
+        :param condition: A SQLAlchemy ColumnExpression. Left side must be a column object.
+        :param links: A list of models defining the relationship path between the target model and the condition model.
         """
 
-        if value is None or value == "":
+        links = links or []
+
+        for model in links:
+            if model.__table__ not in self.stmt.get_final_froms():
+                self.stmt = self.stmt.join(model)
+
+        if not condition.is_clause_element:
+            raise ValueError("Condition must be valid clause.")
+
+        if not isinstance(condition.left, Column):
+            raise ValueError("Expected column on the left side of the expression.")
+
+        if isinstance(condition.right, Null) or condition.right.value == "":
             return
 
-        attr_model = relation or self.model
-        attr_model_mapper = inspect(attr_model)
-        if attr in attr_model_mapper.columns:
-            model_column = attr_model_mapper.columns[attr]
-            value = coerce_to_column_type(model_column, value)
+        if condition.left.table not in self.stmt.get_final_froms():
+            self.stmt = self.stmt.join(condition.left.entity_namespace)
 
-        if relation is not None:
-            rel_key = self.relationships[relation]
-
-            if self.mapper.relationships[rel_key].uselist:
-
-                def condition(obj: Type[Base]) -> bool:
-                    model_attr = getattr(obj, rel_key)
-                    return any(getattr(item, attr) == value for item in model_attr)
-
-            else:
-
-                def condition(obj: Type[Base]) -> bool:
-                    model_attr = getattr(getattr(obj, rel_key), attr)
-                    return model_attr == value
-
-        else:
-
-            def condition(obj: Type[Base]) -> bool:
-                model_attr = getattr(obj, attr)
-                if match is Match.EXACT:
-                    return model_attr == value
-                else:
-                    return value.lower() in model_attr.lower()
-
-        self.conditions.append(condition)
-
-    def filter(self, objs: list[Base]) -> list[Base]:
-        """Return a list of objects that match the given criteria."""
-        objs_seq = seq(objs)
-        objs_seq = objs_seq.filter(self)
-        return objs_seq.to_list()
-
-
-if __name__ == "__main__":
-    courses = [
-        Course(code="1234", subject=Subject(subject_id="COMP")),
-        Course(code="5678", subject=Subject(subject_id="COMP")),
-    ]
-
-    course_filter = ModelFilter(Course)
-    course_filter.add_condition("subject_id", "COMP", Subject)
-    course_filter.add_condition("code", "1234")
-    filtered_courses = course_filter.filter(courses)
-    print(filtered_courses)
+        self.stmt = self.stmt.where(condition)

--- a/bcitflex/course.py
+++ b/bcitflex/course.py
@@ -1,36 +1,30 @@
 """Course Blueprint"""
 
 from flask import Blueprint, render_template, request
-from sqlalchemy import select
-from werkzeug.datastructures import ImmutableMultiDict
+from sqlalchemy import not_, select
 
 from bcitflex.app_functions import ModelFilter
-from bcitflex.app_functions.course_query import Match
 from bcitflex.db import DBSession
 from bcitflex.model import Course, Meeting, Offering, Subject, Term
+from bcitflex.model.offering import NOT_AVAILABLE
 
 bp = Blueprint("course", __name__)
-
-
-def filters_from_form(form: ImmutableMultiDict) -> ModelFilter:
-    """Return a list of CourseFilters from the given form."""
-    filters = ModelFilter(Course)
-    filters.add_condition("term_id", form.get("term"), Offering)
-    filters.add_condition("subject_id", form.get("subject"))
-    filters.add_condition("campus", form.get("campus"), Offering)
-    filters.add_condition("code", form.get("code"))
-    filters.add_condition("name", form.get("name"), None, Match.PARTIAL)
-    filters.add_condition("is_available", form.get("available") == "True" or None)
-    return filters
 
 
 @bp.route("/")
 @bp.route("/courses", methods=["GET", "POST"])
 def index():
-    courses = DBSession.scalars(select(Course)).all()
+    filters = ModelFilter(Course)
     if request.method == "POST":
-        print(request.form)
-        courses = filters_from_form(request.form).filter(courses)
+        filters.where(Offering.term_id == request.form.get("term"))
+        filters.where(Course.subject_id == request.form.get("subject"))
+        filters.where(Meeting.campus == request.form.get("campus"))
+        filters.where(Course.code == request.form.get("code"))
+        if name := request.form.get("name"):
+            filters.where(Course.name.ilike("%" + name + "%"))
+        if request.form.get("available") is not None:
+            filters.where(not_(Offering.status.in_(NOT_AVAILABLE)))
+    courses = DBSession.scalars(filters.stmt).all()
     subjects = DBSession.scalars(select(Subject).where(Subject.is_active)).all()
     terms = DBSession.scalars(select(Term).join(Offering)).unique().all()
     locations = DBSession.scalars(select(Meeting.campus).distinct()).all()

--- a/tests/app_functions/test_course_query.py
+++ b/tests/app_functions/test_course_query.py
@@ -1,12 +1,14 @@
 """Tests for the CourseFilter class and course query function."""
 import pytest
+from sqlalchemy import Select, select
 
-from bcitflex.app_functions.course_query import (
-    Match,
-    ModelFilter,
-    coerce_to_column_type,
-)
-from bcitflex.model import Course, Offering, Subject
+from bcitflex.app_functions.course_query import ModelFilter
+from bcitflex.model import Course, Meeting, Offering
+
+
+def one_line(stmt: Select) -> str:
+    """Transform statement to one line string."""
+    return str(stmt).replace("\n", "")
 
 
 @pytest.fixture(scope="function")
@@ -15,100 +17,69 @@ def course_filter():
     return ModelFilter(Course)
 
 
-@pytest.fixture
-def courses():
-    """Return a list of Course instances."""
-    return [
-        Course(code="1234", name="Test Course", subject=Subject(subject_id="COMP")),
-        Course(
-            code="5678",
-            subject=Subject(subject_id="COMP"),
-            name="Second Course",
-            offerings=[Offering(term_id="202101")],
-        ),
-    ]
-
-
-class TestHelperFunctions:
-    """Test the helper functions of course_query.py."""
-
-    @pytest.mark.parametrize(
-        "model_column, value, expected",
-        [
-            (Course.code, 1234, "1234"),
-            (Course.code, "1234", "1234"),
-        ],
-    )
-    def test_coerce_to_column_type(self, model_column, value, expected):
-        """Test the coerce_to_column_type function."""
-        coerced_value = coerce_to_column_type(model_column, value)
-        assert isinstance(coerced_value, str)
-        assert coerced_value == expected
+@pytest.fixture(scope="function")
+def base_stmt(course_filter):
+    """Return the base ModelFilter statement."""
+    return one_line(select(Course).distinct())
 
 
 class TestModelFilter:
     """Test the ModelFilter class."""
 
-    def test_add_condition(self, course_filter: ModelFilter):
-        """Test that the add_condition method adds a condition."""
-        course_filter.add_condition("code", "1234")
-        assert len(course_filter.conditions) == 1
+    def test_init(self, course_filter: ModelFilter, base_stmt: str):
+        """Test select statement initialization."""
+        assert one_line(course_filter.stmt) == base_stmt
 
-    def test_add_condition_none(self, course_filter: ModelFilter):
-        """Test that add_condition does not add a condition if the value is None."""
-        course_filter.add_condition("code", None)
-        assert len(course_filter.conditions) == 0
+    def test_add_condition(self, course_filter: ModelFilter, base_stmt: str):
+        """Test that the condition method adds a where clause."""
+        base_stmt += " WHERE course.code = :code_1"
+        course_filter.where(Course.code == "1234")
+        assert one_line(course_filter.stmt) == base_stmt
 
-    def test_add_condition_blank(self, course_filter: ModelFilter):
+    def test_add_condition_none(self, course_filter: ModelFilter, base_stmt: str):
+        """Test that condition does not add a clause if the value is None."""
+        course_filter.where(Course.code.is_(None))
+        assert one_line(course_filter.stmt) == base_stmt
+
+    def test_add_condition_blank(self, course_filter: ModelFilter, base_stmt: str):
         """Test that add_condition does not add a condition if the value is blank."""
-        course_filter.add_condition("code", "")
-        assert len(course_filter.conditions) == 0
+        course_filter.where(Course.code == "")
+        assert one_line(course_filter.stmt) == base_stmt
 
-    def test_add_rel_condition(self, course_filter: ModelFilter):
-        """Test the add_condition method with a relationship."""
-        course_filter.add_condition("subject_id", "COMP", Subject)
-        assert len(course_filter.conditions) == 1
+    def test_add_multi_condition(self, course_filter: ModelFilter, base_stmt: str):
+        """Test adding multiple conditions."""
+        base_stmt += " WHERE course.code = :code_1"
+        base_stmt += " AND course.subject_id = :subject_id_1"
+        course_filter.where(Course.code == "1234")
+        course_filter.where(Course.subject_id == "COMP")
+        assert one_line(course_filter.stmt) == base_stmt
 
-    def test_filter(self, course_filter: ModelFilter, courses):
-        """Test the filter method."""
-        course_filter.add_condition("code", "1234")
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 1
-        assert filtered_courses[0].code == "1234"
+    def test_add_rel_condition(self, course_filter: ModelFilter, base_stmt: str):
+        """Test adding condition for related table."""
+        base_stmt += " JOIN offering ON course.course_id = offering.course_id"
+        base_stmt += " WHERE offering.status = :status_1"
+        course_filter.where(Offering.status == "Full")
+        assert one_line(course_filter.stmt) == base_stmt
 
-    def test_filter_rel(self, course_filter: ModelFilter, courses):
+    def test_add_distant_rel_condition(
+        self, course_filter: ModelFilter, base_stmt: str
+    ):
+        """Test adding a condition for an indirectly related table."""
+        base_stmt += " JOIN offering ON course.course_id = offering.course_id"
+        base_stmt += " JOIN meeting ON offering.offering_id = meeting.offering_id"
+        base_stmt += " WHERE meeting.campus = :campus_1"
+        course_filter.where(Meeting.campus == "Burnaby", [Offering])
+        assert one_line(course_filter.stmt) == base_stmt
+
+    def test_add_condition_collection(self, course_filter: ModelFilter, base_stmt: str):
+        """Test adding a condition with an IN operator."""
+        base_stmt += " JOIN offering ON course.course_id = offering.course_id"
+        base_stmt += " WHERE offering.status IN (__[POSTCOMPILE_status_1])"
+        course_filter.where(Offering.status.in_(["Full", "Cancelled"]))
+        assert one_line(course_filter.stmt) == base_stmt
+
+    def test_filter_partial_match(self, course_filter: ModelFilter, base_stmt: str):
         """Test the filter method with a relationship."""
-        course_filter.add_condition("subject_id", "COMP", Subject)
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 2
-        assert filtered_courses[0].subject.subject_id == "COMP"
-
-    def test_filter_rel_collection(self, course_filter: ModelFilter, courses):
-        """Test the filter method with a relationship."""
-        course_filter.add_condition("term_id", "202101", Offering)
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 1
-        assert filtered_courses[0].offerings[0].term_id == "202101"
-
-    def test_filter_name_course(self, course_filter: ModelFilter, courses):
-        """Test the filter method with a relationship."""
-        course_filter.add_condition("name", "Test Course")
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 1
-        assert filtered_courses[0].name == "Test Course"
-
-    def test_filter_exact_match(self, course_filter: ModelFilter, courses):
-        """Test the filter method with a relationship."""
-        course_filter.add_condition("name", "cours")
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 0
-
-    def test_filter_partial_match(self, course_filter: ModelFilter, courses):
-        """Test the filter method with a relationship."""
-        course_filter.add_condition("name", "cours", None, Match.PARTIAL)
-        filtered_courses = course_filter.filter(courses)
-        assert len(filtered_courses) == 2
-        assert list(map(lambda x: x.name, filtered_courses)) == [
-            "Test Course",
-            "Second Course",
-        ]
+        base_stmt += " WHERE lower(course.name) LIKE lower(:name_1)"
+        course_filter.where(Course.name.ilike("%cours%"))
+        assert one_line(course_filter.stmt) == base_stmt


### PR DESCRIPTION
Apply course filters via SQL instead of in state. It is more efficient to filter courses at the database level. Allows us to utilize Flask-SQLAlchemy's paginate function for #36.

Replaces #74 